### PR TITLE
Feature: 의뢰, 입찰 진행상황별 알림 기능 구현 (진행중) - 1차 확인

### DIFF
--- a/src/main/java/com/example/demo/src/bid/domain/Bid.java
+++ b/src/main/java/com/example/demo/src/bid/domain/Bid.java
@@ -20,6 +20,10 @@ public class Bid {
     @Column(name = "price", nullable = false)
     private Long price;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private BidStatus status;
+
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "email", nullable = false)
     private Member member; //멘토들
@@ -29,10 +33,15 @@ public class Bid {
     private Suggestion suggestion;
 
     @Builder
-    public Bid(Long price, Member member, Suggestion suggestion){
+    public Bid(Long price, BidStatus status, Member member, Suggestion suggestion){
         this.price = price;
+        this.status = status;
         this.member = member;
         this.suggestion = suggestion;
+    }
+
+    public void updateStatus(BidStatus status){
+        this.status = status;
     }
 }
 

--- a/src/main/java/com/example/demo/src/bid/domain/BidStatus.java
+++ b/src/main/java/com/example/demo/src/bid/domain/BidStatus.java
@@ -1,0 +1,5 @@
+package com.example.demo.src.bid.domain;
+
+public enum BidStatus {
+    진행중, 완료
+}

--- a/src/main/java/com/example/demo/src/bid/repository/BidRepository.java
+++ b/src/main/java/com/example/demo/src/bid/repository/BidRepository.java
@@ -1,6 +1,8 @@
 package com.example.demo.src.bid.repository;
 
 import com.example.demo.src.bid.domain.Bid;
+import com.example.demo.src.bid.domain.BidStatus;
+import com.example.demo.src.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +20,5 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     void deleteBidsByIdIn(@Param("bidIds") List<Long> bidIds);
 
     Optional<Bid> findBySuggestion_SuggestionIdx(Long suggestionIdx);
+    List<Bid> findBidBySuggestionMemberAndStatus(Member member, BidStatus status);
 }

--- a/src/main/java/com/example/demo/src/member/controller/MemberController.java
+++ b/src/main/java/com/example/demo/src/member/controller/MemberController.java
@@ -131,4 +131,16 @@ public class MemberController {
                 .orElse(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
 
+    @GetMapping("/notification")
+    public ResponseEntity getNotification(@AuthenticationPrincipal(expression = "username") String username,
+                                          @AuthenticationPrincipal(expression = "authorities[0].authority") String authority){
+        Object notificationRes = memberAuthService.getNotification(username, authority);
+
+        return ResponseEntity.ok().body(
+                CommonResponse.builder()
+                        .success(true)
+                        .response(notificationRes)
+                        .build()
+        );
+    }
 }

--- a/src/main/java/com/example/demo/src/member/domain/Member.java
+++ b/src/main/java/com/example/demo/src/member/domain/Member.java
@@ -51,6 +51,9 @@ public class Member {
     @Column(name = "activated", nullable = false) //계정 활성 여부?
     private boolean activated;
 
+    @Column(name = "checkedAlarm", columnDefinition = "BOOL DEFAULT false")
+    private boolean checkedAlarm;
+
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "member")
     private Account account;
 
@@ -67,7 +70,7 @@ public class Member {
     @Builder
     public Member(String email, String password, String name, String phoneNumber, Long age,
                   String userImage, String career, String category, Long balance, Long tokenWeight,
-                  boolean activated, Account account, Authority authority){
+                  boolean activated, boolean checkedAlarm, Account account, Authority authority){
         this.username = email;
         this.password = password;
         this.name = name;
@@ -81,6 +84,7 @@ public class Member {
         this.activated = activated;
         this.account = account;
         this.authority = authority;
+        this.checkedAlarm = checkedAlarm;
     }
 
     public void increaseTokenWeight(){
@@ -115,7 +119,12 @@ public class Member {
     public void addSuggestion(Suggestion suggestion){
         this.suggestionList.add(suggestion);
     }
+
     public void addBid(Bid bid) {
         this.bidList.add(bid);
+    }
+
+    public void updateAlarmStatus(boolean status){
+        this.checkedAlarm = status;
     }
 }

--- a/src/main/java/com/example/demo/src/member/dto/MenteeNotificationRes.java
+++ b/src/main/java/com/example/demo/src/member/dto/MenteeNotificationRes.java
@@ -1,0 +1,24 @@
+package com.example.demo.src.member.dto;
+
+import com.example.demo.src.bid.domain.Bid;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MenteeNotificationRes {
+    private Long bidIdx;
+    private Long price;
+    private String mentorName;
+    private String suggestionTitle;
+
+    public static MenteeNotificationRes of(Bid bid){
+        return MenteeNotificationRes.builder()
+                .bidIdx(bid.getBidIdx())
+                .price(bid.getPrice())
+                .mentorName(bid.getMember().getName())
+                .suggestionTitle(bid.getSuggestion().getTitle())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/demo/src/member/dto/MentorNotificationRes.java
+++ b/src/main/java/com/example/demo/src/member/dto/MentorNotificationRes.java
@@ -1,0 +1,23 @@
+package com.example.demo.src.member.dto;
+
+import com.example.demo.src.suggestion.domain.Suggestion;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MentorNotificationRes {
+    private Long suggestionIdx;
+    private String suggestionTitle;
+    private String suggester;
+    private Boolean suggestionStatus;
+
+    public static MentorNotificationRes of(Suggestion suggestion, Boolean suggestionStatus){
+        return MentorNotificationRes.builder()
+                .suggestionIdx(suggestion.getSuggestionIdx())
+                .suggestionTitle(suggestion.getTitle())
+                .suggester(suggestion.getMember().getName())
+                .suggestionStatus(suggestionStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/src/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/demo/src/member/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
     @Query("select m from Member m where m.username=:memberEmail and m.activated=false")
     Optional<Member> findDeletedUserByMemberEmail(String memberEmail);
+    List<Member> findMembersByCategory(String category);
 }

--- a/src/main/java/com/example/demo/src/member/service/MemberAuthService.java
+++ b/src/main/java/com/example/demo/src/member/service/MemberAuthService.java
@@ -8,11 +8,15 @@ import com.example.demo.global.security.RefreshTokenProvider;
 import com.example.demo.global.security.TokenProvider;
 import com.example.demo.src.S3Service;
 import com.example.demo.src.account.domain.Account;
+import com.example.demo.src.bid.domain.BidStatus;
+import com.example.demo.src.bid.repository.BidRepository;
 import com.example.demo.src.member.domain.AuthAdapter;
 import com.example.demo.src.member.domain.Authority;
 import com.example.demo.src.member.domain.Member;
 import com.example.demo.src.member.dto.*;
 import com.example.demo.src.member.repository.MemberRepository;
+import com.example.demo.src.suggestion.domain.Suggestion;
+import com.example.demo.src.suggestion.repository.SuggestionRepository;
 import com.example.demo.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import net.nurigo.java_sdk.api.Message;
@@ -28,12 +32,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.beans.factory.annotation.Value;
 
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Random;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -43,6 +46,8 @@ public class MemberAuthService {
     private final RefreshTokenProvider refreshTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final MemberRepository memberRepository;
+    private final SuggestionRepository suggestionRepository;
+    private final BidRepository bidRepository;
     private final SecurityUtil securityUtil;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -55,6 +60,39 @@ public class MemberAuthService {
 
     @Value("${sns.service.api-secret-key}")
     private String apiSecretKey;
+
+    public Object getNotification(final String username, final String authority) {
+        Member member = memberRepository.findMemberByUsername(username);
+        String category = member.getCategory();
+        Object res;
+
+        if (authority.equals("ROLE_MENTOR")) {
+            List<Suggestion> getFromSuggestions = suggestionRepository.findByCategory(category);
+            List<Suggestion> terminatedSuggestions = suggestionRepository.findSuggestionsWithCompleteBidsAndMember(member);
+
+            List<Suggestion> notifications = getFromSuggestions.stream()
+                    .filter(suggestion -> !terminatedSuggestions.contains(suggestion))
+                    .collect(Collectors.toList());
+
+            Map<Suggestion, Boolean> notificationMap = new HashMap<>();
+            notifications.forEach(suggestion -> notificationMap.put(suggestion, false));
+
+            suggestionRepository.findSuggestionsWithInCompleteBidsAndMember(member)
+                    .forEach(suggestion -> notificationMap.put(suggestion, true));
+
+            res = notificationMap.entrySet().stream()
+                    .sorted(Comparator.comparingLong(entry-> -entry.getKey().getSuggestionIdx()))
+                    .map(entry -> MentorNotificationRes.of(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList());
+        } else {
+            res = bidRepository.findBidBySuggestionMemberAndStatus(member, BidStatus.진행중)
+                    .stream()
+                    .map(MenteeNotificationRes::of)
+                    .collect(Collectors.toList());
+        }
+        member.updateAlarmStatus(false);
+        return res;
+    }
 
     public ResponseLogin login(final String username, final String password) {
         UsernamePasswordAuthenticationToken authenticationToken =

--- a/src/main/java/com/example/demo/src/suggestion/repository/SuggestionRepository.java
+++ b/src/main/java/com/example/demo/src/suggestion/repository/SuggestionRepository.java
@@ -1,7 +1,10 @@
 package com.example.demo.src.suggestion.repository;
 
+import com.example.demo.src.member.domain.Member;
 import com.example.demo.src.suggestion.domain.Suggestion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +14,12 @@ public interface SuggestionRepository extends JpaRepository<Suggestion, Long> {
     List<Suggestion> findByCategory(String category);
     Suggestion findByMemberName(String email);
     Optional<Suggestion> findByTitle(String title);
+
+    @Modifying
+    @Query("SELECT DISTINCT s FROM Suggestion s JOIN s.bids b WHERE b.status = '완료' AND b.member = :member")
+    List<Suggestion> findSuggestionsWithCompleteBidsAndMember(Member member);
+
+    @Modifying
+    @Query("SELECT DISTINCT s FROM Suggestion s JOIN s.bids b WHERE b.status = '진행중' AND b.member = :member")
+    List<Suggestion> findSuggestionsWithInCompleteBidsAndMember(Member member);
 }

--- a/src/main/java/com/example/demo/src/suggestion/service/SuggestionServiceImpl.java
+++ b/src/main/java/com/example/demo/src/suggestion/service/SuggestionServiceImpl.java
@@ -34,8 +34,10 @@ public class SuggestionServiceImpl implements SuggestionService {
                 .price(suggestionDto.getPrice())
                 .member(mentee)
                 .build();
+        List<Member> mentors = memberRepository.findMembersByCategory(suggestionDto.getCategory());
         suggestionRepository.save(suggestion);
         mentee.addSuggestion(suggestion);
+        mentors.forEach(member -> member.updateAlarmStatus(true));
     }
 
     @Override


### PR DESCRIPTION
### 코드 작성 이유
의뢰, 입찰 진행 상황 별 알림 기능 구현
<br>

### 상세 사항
- 멘토 : 멘티가 의뢰를 요청 시 관련 카테고리를 가진 멘토들에게 알림 노출, 완료된 의뢰는 노출 되지 않음
- 멘티 : 해당 멘티가 요청한 의뢰 건에 관해 멘토가 입찰 건을 요청 시 알림 노출, 완료된 의뢰 및 입찰은 노출 되지 않음
<br>

### 참고 사항
Member, Bid, Suggestion 도메인에 변경 사항이 있어, 담당하신 분들은 코드 확인 부탁드립니다.